### PR TITLE
Add SSM Parameter Store permissions

### DIFF
--- a/services/ssm.md
+++ b/services/ssm.md
@@ -6,15 +6,20 @@
 | [ssm:CreateDocument](http://docs.aws.amazon.com/ssm/latest/APIReference/API_CreateDocument.html) | Creates an SSM document. | ??? | - |
 | [ssm:DeleteAssociation](http://docs.aws.amazon.com/ssm/latest/APIReference/API_DeleteAssociation.html) | Disassociates the specified SSM document from the specified instance. | ??? | - |
 | [ssm:DeleteDocument](http://docs.aws.amazon.com/ssm/latest/APIReference/API_DeleteDocument.html) | Deletes the SSM document and all instance associations to the document. | ??? | - |
+| [ssm:DeleteParameter](http://docs.aws.amazon.com/systems-manager/latest/APIReference/API_DeleteParameter.html) | Delete a parameter from the system. | arn:aws:ssm:$region:$account:parameter/$name | - |
 | [ssm:DescribeAssociation](http://docs.aws.amazon.com/ssm/latest/APIReference/API_DescribeAssociation.html) | Describes the associations for the specified SSM document or instance. | ??? | - |
 | [ssm:DescribeDocument](http://docs.aws.amazon.com/ssm/latest/APIReference/API_DescribeDocument.html) | Describes the specified SSM document. | ??? | - |
 | [ssm:DescribeDocumentPermission](http://docs.aws.amazon.com/ssm/latest/APIReference/API_DescribeDocumentPermission.html) | Describes the permissions for an SSM document. | ??? | - |
 | [ssm:DescribeInstanceInformation](http://docs.aws.amazon.com/ssm/latest/APIReference/API_DescribeInstanceInformation.html) | Describes one or more of your instances. | ??? | - |
+| [ssm:DescribeParameters](http://docs.aws.amazon.com/systems-manager/latest/APIReference/API_DescribeParameters.html) | Get information about a parameter. | * | - |
 | [ssm:GetDocument](http://docs.aws.amazon.com/ssm/latest/APIReference/API_GetDocument.html) | Gets the contents of the specified SSM document. | ??? | - |
+| [ssm:GetParameterHistory](http://docs.aws.amazon.com/systems-manager/latest/APIReference/API_GetParameterHistory.html) | Query a list of all parameters used by the AWS account. | arn:aws:ssm:$region:$account:parameter/$name | - |
+| [ssm:GetParameters](http://docs.aws.amazon.com/systems-manager/latest/APIReference/API_GetParameters.html) | Get details of a parameter. | arn:aws:ssm:$region:$account:parameter/$name | - |
 | [ssm:ListAssociations](http://docs.aws.amazon.com/ssm/latest/APIReference/API_ListAssociations.html) | Lists the associations for the specified SSM document or instance. | ??? | - |
 | [ssm:ListCommandInvocations](http://docs.aws.amazon.com/ssm/latest/APIReference/API_ListCommandInvocations.html) | An invocation is copy of a command sent to a specific instance. | ??? | - |
 | [ssm:ListCommands](http://docs.aws.amazon.com/ssm/latest/APIReference/API_ListCommands.html) | Lists the commands requested by users of the AWS account. | ??? | - |
 | [ssm:ListDocuments](http://docs.aws.amazon.com/ssm/latest/APIReference/API_ListDocuments.html) | Describes one or more of your SSM documents. | ??? | - |
 | [ssm:ModifyDocumentPermission](http://docs.aws.amazon.com/ssm/latest/APIReference/API_ModifyDocumentPermission.html) | Share a document publicly or privately. | ??? | - |
+| [ssm:PutParameter](http://docs.aws.amazon.com/systems-manager/latest/APIReference/API_PutParameter.html) | Add one or more parameters to the system. | arn:aws:ssm:$region:$account:parameter/$name | - |
 | [ssm:SendCommand](http://docs.aws.amazon.com/ssm/latest/APIReference/API_SendCommand.html) | Executes commands on one or more remote instances. | ??? | - |
 | [ssm:UpdateAssociationStatus](http://docs.aws.amazon.com/ssm/latest/APIReference/API_UpdateAssociationStatus.html) | Updates the status of the SSM document associated with the specified instance. | ??? | - |


### PR DESCRIPTION
A few notes:

* Some of the descriptions seem mixed up, like DescribeParameters, but I confirmed them with multiple official AWS docs.  Might file an issue with them to make sure it's correct.
* There are more API commands according to the AWS docs, but these are the only ones that show up in policysim.