### PR TITLE
Add cloudwatch dashboard permissions

### DIFF
--- a/services/cloudwatch.md
+++ b/services/cloudwatch.md
@@ -7,7 +7,7 @@
 | [cloudwatch:DescribeAlarmsForMetric](http://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_DescribeAlarmsForMetric.html) | Retrieves all alarms for a single metric. | * | - |
 | [cloudwatch:DisableAlarmActions](http://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_DisableAlarmActions.html) | Disables actions for the specified alarms. | * | - |
 | [cloudwatch:EnableAlarmActions](http://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_EnableAlarmActions.html) | Enables actions for the specified alarms. | * | - |
-| [cloudwatch:GetDashboard](http://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_GetMetricData.html) | Displays the details of the dashboard that you specify.  | * | - |
+| [cloudwatch:GetDashboard](http://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_GetDashboard.html) | Displays the details of the dashboard that you specify.  | * | - |
 | [cloudwatch:GetMetricData](http://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_GetMetricData.html) | ??? | * | - |
 | [cloudwatch:GetMetricStatistics](http://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_GetMetricStatistics.html) | Gets statistics for the specified metric. | * | - |
 | [cloudwatch:ListDashboards](http://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_ListDashboards.html) | Returns a list of the dashboards for your account. | * | - |

--- a/services/cloudwatch.md
+++ b/services/cloudwatch.md
@@ -1,14 +1,18 @@
 | Action | Description | Resource | Condition |
 | --- | --- | --- | --- |
 | [cloudwatch:DeleteAlarms](http://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_DeleteAlarms.html) | Deletes all specified alarms. | * | - |
+| [cloudwatch:DeleteDashboards](http://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_DeleteDashboards.html) | Deletes all dashboards that you specify. | * | - |
 | [cloudwatch:DescribeAlarmHistory](http://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_DescribeAlarmHistory.html) | Retrieves history for the specified alarm. | * | - |
 | [cloudwatch:DescribeAlarms](http://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_DescribeAlarms.html) | Retrieves alarms with the specified names. | * | - |
 | [cloudwatch:DescribeAlarmsForMetric](http://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_DescribeAlarmsForMetric.html) | Retrieves all alarms for a single metric. | * | - |
 | [cloudwatch:DisableAlarmActions](http://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_DisableAlarmActions.html) | Disables actions for the specified alarms. | * | - |
 | [cloudwatch:EnableAlarmActions](http://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_EnableAlarmActions.html) | Enables actions for the specified alarms. | * | - |
+| [cloudwatch:GetDashboard](http://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_GetMetricData.html) | Displays the details of the dashboard that you specify.  | * | - |
 | [cloudwatch:GetMetricData](http://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_GetMetricData.html) | ??? | * | - |
 | [cloudwatch:GetMetricStatistics](http://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_GetMetricStatistics.html) | Gets statistics for the specified metric. | * | - |
+| [cloudwatch:ListDashboards](http://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_ListDashboards.html) | Returns a list of the dashboards for your account. | * | - |
 | [cloudwatch:ListMetrics](http://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_ListMetrics.html) | Returns a list of valid metrics stored for the AWS account owner. | * | - |
+| [cloudwatch:PutDashboard](http://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_PutDashboard.html) | Creates a dashboard if it does not already exist, or updates an existing dashboard. | * | - |
 | [cloudwatch:PutMetricAlarm](http://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_PutMetricAlarm.html) | Creates or updates an alarm and associates it with the specified Amazon CloudWatch metric. | * | - |
 | [cloudwatch:PutMetricData](http://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_PutMetricData.html) | Publishes metric data points to Amazon CloudWatch. | * | - |
 | [cloudwatch:SetAlarmState](http://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_SetAlarmState.html) | Temporarily sets the state of an alarm for testing purposes. | * | - |


### PR DESCRIPTION
Please make sure to provide all the fields! Example below!

* Service: 
* Action: 
* Action documentation: 
* Resources:
* Conditions: 
* Source: 

## Example

* Service: ec2
* Action: DeleteCustomerGateway
* Action documentation: http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DeleteCustomerGateway.html
* Resources: arn:aws:ec2:$region:$account:customer-gateway/$cgw-id
* Conditions: ec2:Region, ec2:ResourceTag/$tag-key
* Source: http://docs.aws.amazon.com/AWSEC2/latest/APIReference/ec2-api-permissions.html and https://docs.aws.amazon.com/IAM/latest/UserGuide/list_ec2.html
