### PR TITLE
Added logs:ListTagsLogGroup to logs.md

### DIFF
--- a/services/logs.md
+++ b/services/logs.md
@@ -18,6 +18,7 @@
 | [logs:DescribeSubscriptionFilters](http://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_DescribeSubscriptionFilters.html) | Returns all the subscription filters associated with the specified log group. | ??? | - |
 | [logs:FilterLogEvents](http://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_FilterLogEvents.html) | Retrieves log events, optionally filtered by a filter pattern from the specified log group. | ??? | - |
 | [logs:GetLogEvents](http://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_GetLogEvents.html) | Retrieves log events from the specified log stream. | ??? | - |
+| [logs:ListTagsLogGroup](https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_ListTagsLogGroup.html) | Lists the tags for the specified log group. | ??? | - |
 | [logs:PutDestination](http://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutDestination.html) | Creates or updates a Destination. | ??? | - |
 | [logs:PutDestinationPolicy](http://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutDestinationPolicy.html) | Creates or updates an access policy associated with an existing Destination. | ??? | - |
 | [logs:PutLogEvents](http://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutLogEvents.html) | Uploads a batch of log events to the specified log stream. | ??? | - |


### PR DESCRIPTION
Just a missing entry on logs, not sure what the '???' stands for but followed convention of the rest of the file.

Service: Cloudwatch Logs
Action: ListTagsLogGroup
Action documentation: https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_ListTagsLogGroup.html
Resources: ???
Conditions: -
Source: https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_ListTagsLogGroup.html

**By opening a Pull Request, you agree that your contribution is licensed under CC0 1.0 Universell (CC0 1.0)**

Please make sure to provide all the fields! Example below!

* Service: 
* Action: 
* Action documentation: 
* Resources:
* Conditions: 
* Source: 

## Example

* Service: ec2
* Action: DeleteCustomerGateway
* Action documentation: http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DeleteCustomerGateway.html
* Resources: arn:aws:ec2:$region:$account:customer-gateway/$cgw-id
* Conditions: ec2:Region, ec2:ResourceTag/$tag-key
* Source: http://docs.aws.amazon.com/AWSEC2/latest/APIReference/ec2-api-permissions.html and https://docs.aws.amazon.com/IAM/latest/UserGuide/list_ec2.html
