### PR TITLE
S3: Fix Erroneously Swapped Descriptions for ReplicateDelete and ReplicateObject

### DIFF
--- a/services/s3.md
+++ b/services/s3.md
@@ -57,7 +57,7 @@
 | [s3:PutObjectTagging](https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPUTtagging.html) | This implementation of the PUT operation uses the tagging subresource to add a set of tags to an existing object. | arn:aws:s3:::$bucket-name/$key-name | ??? |
 | [s3:PutObjectVersionAcl](http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPUTacl.html#objectPutAclVersions) | This implementation of the PUT operation uses the acl subresource to set the access control list (ACL) permissions for an object that already exists in a bucket. | arn:aws:s3:::$bucket-name/$key-name | s3:VersionId, s3:x-amz-acl, s3:x-amz-grant-$permission |
 | [s3:PutReplicationConfiguration](https://docs.aws.amazon.com/IAM/latest/UserGuide/list_s3.html) | Sets/Deletes the replication configuration for an existing bucket. | arn:aws:s3:::$bucket-name | - |
-| [s3:ReplicateDelete](https://docs.aws.amazon.com/IAM/latest/UserGuide/list_s3.html) | Replicates an object to the specified destination object via a replication configuration. | arn:aws:s3:::$bucket-name/$key-name | - |
-| [s3:ReplicateObject](https://docs.aws.amazon.com/IAM/latest/UserGuide/list_s3.html) | Replicates the delete marker of an object to the specified destination object via a replication configuration. | arn:aws:s3:::$bucket-name/$key-name | - |
+| [s3:ReplicateDelete](https://docs.aws.amazon.com/IAM/latest/UserGuide/list_s3.html) | Replicates the delete marker of an object to the specified destination object via a replication configuration. | arn:aws:s3:::$bucket-name/$key-name | - |
+| [s3:ReplicateObject](https://docs.aws.amazon.com/IAM/latest/UserGuide/list_s3.html) | Replicates an object to the specified destination object via a replication configuration. | arn:aws:s3:::$bucket-name/$key-name | - |
 | [s3:RestoreObject](http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPOSTrestore.html) | Restores a temporary copy of an archived object. | arn:aws:s3:::$bucket-name/$key-name | - |
 


### PR DESCRIPTION
**By opening a Pull Request, you agree that your contribution is licensed under CC0 1.0 Universell (CC0 1.0)**

This fixes the erroneously swapped descriptions for ReplicateDelete and ReplicateObject from #80 

* Service: S3
* Action: 
* Action documentation: ReplicateDelete, ReplicateObject
* Resources:
* Conditions: 
* Source: N/A
